### PR TITLE
fix(Metrics): Avoid `hot-shots` type dependency

### DIFF
--- a/src/metricsMiddleware/metricsMiddleware.test.ts
+++ b/src/metricsMiddleware/metricsMiddleware.test.ts
@@ -29,10 +29,9 @@ describe('metricsMiddleware', () => {
 
     expect(mockTiming).toHaveBeenCalledTimes(1);
 
-    const [name, latency, sample, tags] = mockTiming.mock.calls[0] as unknown[];
+    const [name, latency, tags] = mockTiming.mock.calls[0] as unknown[];
     expect(name).toBe('request');
     expect(latency).toBeGreaterThanOrEqual(0);
-    expect(sample).toBeUndefined();
     expect(tags).toEqual({
       http_status: '201',
       http_status_family: '2xx',
@@ -61,10 +60,9 @@ describe('metricsMiddleware', () => {
 
     expect(mockTiming).toHaveBeenCalledTimes(1);
 
-    const [name, latency, sample, tags] = mockTiming.mock.calls[0] as unknown[];
+    const [name, latency, tags] = mockTiming.mock.calls[0] as unknown[];
     expect(name).toBe('request');
     expect(latency).toBeGreaterThanOrEqual(0);
-    expect(sample).toBeUndefined();
     expect(tags).toEqual({
       http_status: '500',
       http_status_family: '5xx',

--- a/src/metricsMiddleware/metricsMiddleware.ts
+++ b/src/metricsMiddleware/metricsMiddleware.ts
@@ -1,5 +1,6 @@
-import { StatsD } from 'hot-shots';
 import Koa from 'koa';
+
+import { StatsD } from './statsD';
 
 /**
  * Returns metrics tags for the passed Koa context
@@ -53,12 +54,7 @@ export const create = (
       const durationNanos = process.hrtime.bigint() - startTime;
 
       if (!ctx.state.skipRequestLogging) {
-        metricsClient.timing(
-          'request',
-          Number(durationNanos) / 1e6,
-          undefined,
-          tags,
-        );
+        metricsClient.timing('request', Number(durationNanos) / 1e6, tags);
       }
     }
   };

--- a/src/metricsMiddleware/statsD.test.ts
+++ b/src/metricsMiddleware/statsD.test.ts
@@ -1,0 +1,13 @@
+import { StatsD as HotShotsStatsD } from 'hot-shots';
+
+import { StatsD as VendoredStatsD } from './statsD';
+
+describe('statsD', () => {
+  it('accepts a hot-shots interface', () => {
+    const hotShots = (true as unknown) as HotShotsStatsD;
+
+    const vendored: VendoredStatsD = hotShots;
+
+    expect(vendored).toBe(true);
+  });
+});

--- a/src/metricsMiddleware/statsD.ts
+++ b/src/metricsMiddleware/statsD.ts
@@ -1,0 +1,9 @@
+type Tags = { [key: string]: string } | string[];
+
+/**
+ * Vendored from `hot-shots.StatsD` so that TypeScript consumers are not forced
+ * to install `hot-shots` when they are not using MetricsMiddleware.
+ */
+export interface StatsD {
+  timing(stat: string | string[], value: number, tags?: Tags): void;
+}


### PR DESCRIPTION
This fixes a long-standing issue where TypeScript consumers were forced to install `hot-shots` to fix the following compilation error:

```text
../node_modules/seek-koala/lib/metricsMiddleware/metricsMiddleware.d.ts(1,24): error TS2307: Cannot find module 'hot-shots' or its corresponding type declarations.
```