### PR TITLE
feat(ErrorMiddleware): JsonErrorResponse

### DIFF
--- a/src/errorMiddleware/README.md
+++ b/src/errorMiddleware/README.md
@@ -37,9 +37,9 @@ app
   .use(ErrorMiddleware.handle);
 ```
 
-## JsonErrorResponse
+## JsonResponse
 
-`JsonErrorResponse` is a custom error type used by `handle` to support JSON error response bodies.
+`JsonResponse` is a custom error type used by `handle` to support JSON error response bodies.
 Its constructor takes a `message` string and a `body` JavaScript value.
 If the request accepts JSON then the error response will include the JSON encoded `body`.
 
@@ -48,7 +48,7 @@ import { ErrorMiddleware } from 'seek-koala';
 
 ctx.throw(
   400,
-  new ErrorMiddleware.JsonErrorResponse('Bad input', {
+  new ErrorMiddleware.JsonResponse('Bad input', {
     message: 'Bad input',
     invalidFields: { '/path/to/field': 'Value out of range' },
   }),

--- a/src/errorMiddleware/README.md
+++ b/src/errorMiddleware/README.md
@@ -36,3 +36,21 @@ app
   .use(metricsMiddleware)
   .use(ErrorMiddleware.handle);
 ```
+
+## JsonErrorResponse
+
+`JsonErrorResponse` is a custom error type used by `handle` to support JSON error response bodies.
+Its constructor takes a `message` string and a `body` JavaScript value.
+If the request accepts JSON then the error response will include the JSON encoded `body`.
+
+```typescript
+import { ErrorMiddleware } from 'seek-koala';
+
+ctx.throw(
+  400,
+  new ErrorMiddleware.JsonErrorResponse('Bad input', {
+    message: 'Bad input',
+    invalidFields: { '/path/to/field': 'Value out of range' },
+  }),
+);
+```

--- a/src/errorMiddleware/errorMiddleware.test.ts
+++ b/src/errorMiddleware/errorMiddleware.test.ts
@@ -98,7 +98,7 @@ describe('errorMiddleware', () => {
     await agent().get('/').set('Accept', 'text/plain').expect(410, 'Gone away');
   });
 
-  it('redact a thrown 5xx `JsonErrorResponse`', async () => {
+  it('redact a thrown 5xx `JsonResponse`', async () => {
     mockNext.mockImplementation((ctx) => {
       ctx.throw(500, new JsonResponse('Bad input', { bad: true }));
     });

--- a/src/errorMiddleware/errorMiddleware.test.ts
+++ b/src/errorMiddleware/errorMiddleware.test.ts
@@ -2,7 +2,7 @@ import Koa from 'koa';
 
 import { agentFromApp } from '../testing/server';
 
-import { handle, thrown } from './errorMiddleware';
+import { JsonErrorResponse, handle, thrown } from './errorMiddleware';
 
 describe('errorMiddleware', () => {
   const mockPrev = jest.fn<unknown, [Koa.Context, Koa.Next]>();
@@ -66,6 +66,41 @@ describe('errorMiddleware', () => {
   it('redacts a thrown 5xx error', async () => {
     mockNext.mockImplementation((ctx) => {
       ctx.throw(500, 'bad');
+    });
+
+    await agent().get('/').expect(500, '');
+  });
+
+  it('exposes a thrown 4xx `JsonErrorResponse` as JSON by default', async () => {
+    mockNext.mockImplementation((ctx) => {
+      ctx.throw(400, new JsonErrorResponse('Bad input', { bad: true }));
+    });
+
+    await agent().get('/').expect(400, { bad: true });
+  });
+
+  it('exposes a thrown 4xx `JsonErrorResponse` as JSON based on `Accept`', async () => {
+    mockNext.mockImplementation((ctx) => {
+      ctx.throw(403, new JsonErrorResponse('No access', { access: false }));
+    });
+
+    await agent()
+      .get('/')
+      .set('Accept', 'application/json')
+      .expect(403, { access: false });
+  });
+
+  it('exposes a thrown 4xx `JsonErrorResponse` as text based on `Accept`', async () => {
+    mockNext.mockImplementation((ctx) => {
+      ctx.throw(410, new JsonErrorResponse('Gone away', { gone: true }));
+    });
+
+    await agent().get('/').set('Accept', 'text/plain').expect(410, 'Gone away');
+  });
+
+  it('redact a thrown 5xx `JsonErrorResponse`', async () => {
+    mockNext.mockImplementation((ctx) => {
+      ctx.throw(500, new JsonErrorResponse('Bad input', { bad: true }));
     });
 
     await agent().get('/').expect(500, '');

--- a/src/errorMiddleware/errorMiddleware.test.ts
+++ b/src/errorMiddleware/errorMiddleware.test.ts
@@ -2,7 +2,7 @@ import Koa from 'koa';
 
 import { agentFromApp } from '../testing/server';
 
-import { JsonErrorResponse, handle, thrown } from './errorMiddleware';
+import { JsonResponse, handle, thrown } from './errorMiddleware';
 
 describe('errorMiddleware', () => {
   const mockPrev = jest.fn<unknown, [Koa.Context, Koa.Next]>();
@@ -71,17 +71,17 @@ describe('errorMiddleware', () => {
     await agent().get('/').expect(500, '');
   });
 
-  it('exposes a thrown 4xx `JsonErrorResponse` as JSON by default', async () => {
+  it('exposes a thrown 4xx `JsonResponse` as JSON by default', async () => {
     mockNext.mockImplementation((ctx) => {
-      ctx.throw(400, new JsonErrorResponse('Bad input', { bad: true }));
+      ctx.throw(400, new JsonResponse('Bad input', { bad: true }));
     });
 
     await agent().get('/').expect(400, { bad: true });
   });
 
-  it('exposes a thrown 4xx `JsonErrorResponse` as JSON based on `Accept`', async () => {
+  it('exposes a thrown 4xx `JsonResponse` as JSON based on `Accept`', async () => {
     mockNext.mockImplementation((ctx) => {
-      ctx.throw(403, new JsonErrorResponse('No access', { access: false }));
+      ctx.throw(403, new JsonResponse('No access', { access: false }));
     });
 
     await agent()
@@ -90,9 +90,9 @@ describe('errorMiddleware', () => {
       .expect(403, { access: false });
   });
 
-  it('exposes a thrown 4xx `JsonErrorResponse` as text based on `Accept`', async () => {
+  it('exposes a thrown 4xx `JsonResponse` as text based on `Accept`', async () => {
     mockNext.mockImplementation((ctx) => {
-      ctx.throw(410, new JsonErrorResponse('Gone away', { gone: true }));
+      ctx.throw(410, new JsonResponse('Gone away', { gone: true }));
     });
 
     await agent().get('/').set('Accept', 'text/plain').expect(410, 'Gone away');
@@ -100,7 +100,7 @@ describe('errorMiddleware', () => {
 
   it('redact a thrown 5xx `JsonErrorResponse`', async () => {
     mockNext.mockImplementation((ctx) => {
-      ctx.throw(500, new JsonErrorResponse('Bad input', { bad: true }));
+      ctx.throw(500, new JsonResponse('Bad input', { bad: true }));
     });
 
     await agent().get('/').expect(500, '');

--- a/src/errorMiddleware/errorMiddleware.ts
+++ b/src/errorMiddleware/errorMiddleware.ts
@@ -9,6 +9,34 @@ const isObject = (value: unknown): value is Record<PropertyKey, unknown> =>
   typeof value === 'object' && value !== null;
 
 /**
+ * Custom error type supporting JSON response bodies
+ *
+ * The `handle` middleware will return either `message` or `body` depending on
+ * the request's `Accept` header.
+ *
+ * ```javascript
+ * ctx.throw(400, new JsonErrorResponse('Invalid input', { fieldName: '/foo' }));
+ * ```
+ */
+export class JsonErrorResponse extends Error {
+  /**
+   * Creates a new `JsonErrorResponse`
+   *
+   * This must be passed to `ctx.throw` instead of being thrown directly.
+   *
+   * @param message - Plain text message used for requests preferring
+   *                  `text/plain`. This is also used as the `Error` superclass
+   *                  message.
+   *
+   * @param body - JavaScript value used for requests accepting
+   *               `application/json`. This is encoded as JSON in the response.
+   */
+  constructor(message: string, public body: unknown) {
+    super(message);
+  }
+}
+
+/**
  * Catches errors thrown from downstream middleware, as specified here:
  *
  * https://github.com/koajs/koa/wiki/Error-Handling#catching-downstream-errors
@@ -16,6 +44,10 @@ const isObject = (value: unknown): value is Record<PropertyKey, unknown> =>
  * This tries to extract a numeric error `status` to serve as the response
  * status, and will set the error message as the response body for non-5xx
  * statuses. It works well with Koa's built-in `ctx.throw`.
+ *
+ * This includes a specific check for the `JsonErrorResponse` class to support
+ * including a JSON response body. If the request accepts `application/json`
+ * the error's `body` will be returned, otherwise its plain text `message`.
  *
  * This should be placed high up the middleware chain so that errors from lower
  * middleware are handled. It also serves to set the correct `ctx.status` for
@@ -43,7 +75,18 @@ export const handle: Middleware = async (ctx, next) => {
     }
 
     ctx.status = err.status;
-    ctx.body = (err.status < 500 && err.message) || '';
+    const expose = err.status < 500;
+
+    if (
+      expose &&
+      err instanceof JsonErrorResponse &&
+      // Prefer JSON ourselves if the request has no preference
+      ctx.accepts(['application/json', 'text/plain']) === 'application/json'
+    ) {
+      ctx.body = err.body;
+    } else {
+      ctx.body = (expose && err.message) || '';
+    }
   }
 };
 

--- a/src/errorMiddleware/errorMiddleware.ts
+++ b/src/errorMiddleware/errorMiddleware.ts
@@ -15,12 +15,12 @@ const isObject = (value: unknown): value is Record<PropertyKey, unknown> =>
  * the request's `Accept` header.
  *
  * ```javascript
- * ctx.throw(400, new JsonErrorResponse('Invalid input', { fieldName: '/foo' }));
+ * ctx.throw(400, new JsonResponse('Invalid input', { fieldName: '/foo' }));
  * ```
  */
-export class JsonErrorResponse extends Error {
+export class JsonResponse extends Error {
   /**
-   * Creates a new `JsonErrorResponse`
+   * Creates a new `JsonResponse`
    *
    * This must be passed to `ctx.throw` instead of being thrown directly.
    *
@@ -45,7 +45,7 @@ export class JsonErrorResponse extends Error {
  * status, and will set the error message as the response body for non-5xx
  * statuses. It works well with Koa's built-in `ctx.throw`.
  *
- * This includes a specific check for the `JsonErrorResponse` class to support
+ * This includes a specific check for the `JsonResponse` class to support
  * including a JSON response body. If the request accepts `application/json`
  * the error's `body` will be returned, otherwise its plain text `message`.
  *
@@ -79,7 +79,7 @@ export const handle: Middleware = async (ctx, next) => {
 
     if (
       expose &&
-      err instanceof JsonErrorResponse &&
+      err instanceof JsonResponse &&
       // Prefer JSON ourselves if the request has no preference
       ctx.accepts(['application/json', 'text/plain']) === 'application/json'
     ) {


### PR DESCRIPTION
This gives us built-in support for exposing JSON error response bodies without per-app hacks. This is useful for returning richer structured errors or e.g. implementing OAuth 2.0.

This makes a big deal about content negotiation with `text/plain`. However, I really only added that as a motivation to keep the `Error.message` sane for logging and debugging.