### PR TITLE
feat(AsyncMiddleware): Add TTL for cache validation

### DIFF
--- a/src/asyncMiddleware/README.md
+++ b/src/asyncMiddleware/README.md
@@ -4,7 +4,7 @@
 
 This add-on wraps an asynchronously-initialised middleware to allow it to be synchronously attached to a Koa application.
 This is useful if you want to keep the initialisation of your Koa application synchronous for simplicity and interoperability with tooling like [Koa Cluster],
-but you need to perform asynchronous work like [GraphQL schema introspection] in order to build one of the middleware in your chain.
+but you need to perform asynchronous work like [GraphQL schema introspection] in order to build one of the middleware in your chain. You can optionally set a TTL so the inner middleware can be reinitialised when the cache has expired.
 
 [koa cluster]: https://github.com/koajs/cluster
 [graphql schema introspection]: https://graphql.org/learn/introspection/
@@ -20,7 +20,7 @@ const initGraphMiddleware: = async () => {
   return new GraphServer(schema).getMiddleware();
 };
 
-const graphMiddleware = AsyncMiddleware.lazyLoad(initGraphMiddleware);
+const graphMiddleware = AsyncMiddleware.lazyLoad(initGraphMiddleware, 120000);
 
 app.use(graphMiddleware);
 ```

--- a/src/asyncMiddleware/asyncMiddleware.ts
+++ b/src/asyncMiddleware/asyncMiddleware.ts
@@ -12,12 +12,16 @@ import { Middleware } from 'koa';
  */
 export const lazyLoad = <State, Context>(
   init: () => Promise<Middleware<State, Context>>,
+  ttl?: number,
 ): Middleware<State, Context> => {
   let cache: Promise<Middleware<State, Context>> | undefined;
+  let cacheTimestamp: number;
 
   const initOrInvalidate = async () => {
     try {
-      return await init();
+      const cacheInit = await init();
+      cacheTimestamp = Date.now();
+      return cacheInit;
     } catch (err) {
       cache = undefined;
 
@@ -26,7 +30,15 @@ export const lazyLoad = <State, Context>(
     }
   };
 
+  const validateCache = () =>
+    typeof cache === 'undefined' ||
+    typeof cacheTimestamp === 'undefined' ||
+    typeof ttl === 'undefined' ||
+    Date.now() - cacheTimestamp < ttl ||
+    (cache = undefined);
+
   return async (ctx, next) => {
+    validateCache();
     const middleware = await (cache ?? (cache = initOrInvalidate()));
 
     return middleware(ctx, next) as unknown;

--- a/src/asyncMiddleware/asyncMiddleware.ts
+++ b/src/asyncMiddleware/asyncMiddleware.ts
@@ -7,8 +7,10 @@ import { Middleware } from 'koa';
  * This lazy loads the function supplied through the `init` parameter at time of
  * request. If initialisation fails, the error is thrown up the chain for
  * in-flight requests, and initialisation is retried on the next request.
+ * If `ttl` is set, the middleware is re-initialised when cache expires.
  *
  * @param init  - Function to asynchronously initialise a middleware
+ * @param ttl - Time in ms
  */
 export const lazyLoad = <State, Context>(
   init: () => Promise<Middleware<State, Context>>,


### PR DESCRIPTION
This adds the option to pass in a TTL so the inner middleware can be reinitialised when cache has expired