### PR TITLE
feat(ErrorMiddleware): Support custom JSON errors

### DIFF
--- a/src/asyncMiddleware/asyncMiddleware.ts
+++ b/src/asyncMiddleware/asyncMiddleware.ts
@@ -24,10 +24,9 @@ export const lazyLoad = <State, Context>(
       const cacheInit = await init();
       cacheTimestamp = Date.now();
       return cacheInit;
-    } catch (err) {
+    } catch (err: unknown) {
       cache = undefined;
 
-      /* eslint-disable-next-line no-throw-literal */
       throw err;
     }
   };

--- a/src/errorMiddleware/README.md
+++ b/src/errorMiddleware/README.md
@@ -54,3 +54,5 @@ ctx.throw(
   }),
 );
 ```
+
+You can also bring your own child Error class by exposing an `isJsonResponse` property set to `true`.

--- a/src/errorMiddleware/errorMiddleware.test.ts
+++ b/src/errorMiddleware/errorMiddleware.test.ts
@@ -90,6 +90,17 @@ describe('errorMiddleware', () => {
       .expect(403, { access: false });
   });
 
+  it('exposes a thrown 4xx custom JSON response as JSON based on `Accept`', async () => {
+    mockNext.mockImplementation((ctx) => {
+      ctx.throw(403, { body: { access: false }, isJsonResponse: true });
+    });
+
+    await agent()
+      .get('/')
+      .set('Accept', 'application/json')
+      .expect(403, { access: false });
+  });
+
   it('exposes a thrown 4xx `JsonResponse` as text based on `Accept`', async () => {
     mockNext.mockImplementation((ctx) => {
       ctx.throw(410, new JsonResponse('Gone away', { gone: true }));

--- a/src/errorMiddleware/errorMiddleware.ts
+++ b/src/errorMiddleware/errorMiddleware.ts
@@ -19,7 +19,11 @@ const isObject = (value: unknown): value is Record<PropertyKey, unknown> =>
  * ```
  */
 export class JsonResponse extends Error {
-  public isJsonResponse = true;
+  /**
+   * The property used by `handle` to infer that this error contains a body that
+   * can be exposed in the HTTP response.
+   */
+  public isJsonResponse = true as const;
 
   /**
    * Creates a new `JsonResponse`

--- a/src/requestLogging/requestLogging.ts
+++ b/src/requestLogging/requestLogging.ts
@@ -132,8 +132,9 @@ export const createMiddleware = <StateT extends State, CustomT>(
     try {
       await next();
       requestFinished({ status: ctx.response.status });
-    } catch (e) {
-      requestFinished({ status: 500, internalErrorString: String(e) }, e);
-      throw e;
+    } catch (err: unknown) {
+      requestFinished({ status: 500, internalErrorString: String(err) }, err);
+
+      throw err;
     }
   };


### PR DESCRIPTION
Currently, other packages that want to expose a JSON response via Koala's `ErrorMiddleware` have to import Koala itself in order to use its `JsonResponse` error class. This proposes a structural approach where we rely on the object to have an `isJsonResponse` property.