### PR TITLE
chore(RequestLogging): Use SuperTest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   },
   "description": "Koa add-ons for SEEK-standard tracing, logging and metrics",
   "devDependencies": {
+    "@koa/router": "9.4.0",
     "@types/koa": "2.11.4",
+    "@types/koa__router": "8.0.3",
     "@types/supertest": "2.0.10",
     "@types/uuid": "8.3.0",
     "hot-shots": "8.2.0",

--- a/src/requestLogging/requestLogging.test.ts
+++ b/src/requestLogging/requestLogging.test.ts
@@ -1,110 +1,166 @@
-import Koa from 'koa';
+import Router, { Middleware } from '@koa/router';
+import Koa, { Context, Next } from 'koa';
+import request from 'supertest';
 
 import { contextFields, createMiddleware } from './requestLogging';
 
 describe('RequestLogging', () => {
+  const createAgent = (...middlewares: Middleware[]) => {
+    const app = new Koa();
+
+    for (const middleware of middlewares) {
+      app.use(middleware);
+    }
+
+    return request.agent(app.callback());
+  };
+
   describe('contextFields', () => {
-    it('returns fields containg request information', () => {
-      const ctx = ({
-        request: {
-          method: 'GET',
-          url: '/foo/bar?baz',
-          header: {
-            'user-agent': 'Safari',
+    it('returns request information for a vanilla handler', () => {
+      const handler = jest.fn((ctx: Context) => {
+        ctx.status = 200;
+        ctx.body = 'hello';
+
+        const fields = contextFields(ctx);
+
+        expect(fields).toMatchInlineSnapshot(
+          {
+            'x-request-id': expect.any(String),
           },
-        },
-        state: {},
-      } as unknown) as Koa.Context;
+          `
+          Object {
+            "method": "GET",
+            "url": "/route/foo?bar",
+            "x-request-id": Any<String>,
+          }
+        `,
+        );
+      });
 
-      const fields = contextFields(ctx);
+      return createAgent(handler)
+        .get('/route/foo?bar')
+        .set('user-agent', 'Safari')
+        .expect(200, 'hello');
+    });
 
-      expect(fields.method).toBe('GET');
-      expect(fields.url).toBe('/foo/bar?baz');
-      expect(fields['x-request-id']).toBeDefined();
-      expect(fields.headers).toBeUndefined();
+    it('returns request information for a @koa/router handler', () => {
+      const router = new Router().get(
+        '/route/:segment',
+        jest.fn((ctx: Context) => {
+          ctx.status = 200;
+          ctx.body = 'hello';
+
+          const fields = contextFields(ctx);
+
+          expect(fields).toMatchInlineSnapshot(
+            {
+              'x-request-id': expect.any(String),
+            },
+            `
+            Object {
+              "method": "GET",
+              "url": "/route/foo?bar",
+              "x-request-id": Any<String>,
+            }
+          `,
+          );
+        }),
+      );
+
+      return createAgent(router.routes())
+        .get('/route/foo?bar')
+        .set('user-agent', 'Safari')
+        .expect(200, 'hello');
     });
   });
 
   describe('createMiddleware', () => {
     it('logs a successful request', async () => {
+      const handler = jest.fn((ctx: Context) => {
+        ctx.status = 201;
+      });
+
       const logMock = jest.fn();
-      const ctx = ({
-        request: {
-          method: 'POST',
-          url: '/my/test/service',
-          header: {
-            'Authenticated-User': 'somesercret',
-            'user-agent': 'Safari',
-          },
-        },
-        response: {
-          status: 404,
-        },
-        state: {},
-      } as unknown) as Koa.Context;
 
       const middleware = createMiddleware(logMock);
 
-      await middleware(ctx, () => {
-        ctx.response.status = 201;
-        return Promise.resolve();
-      });
+      await createAgent(middleware, handler)
+        .post('/my/test/service')
+        .set('Authenticated-User', 'somesercret')
+        .set('user-agent', 'Safari')
+        .expect(201);
 
       expect(logMock).toBeCalledTimes(1);
 
-      const [logCtx, fields, error] = logMock.mock.calls[0] as unknown[];
+      const [, fields, err] = logMock.mock.calls[0];
 
-      expect(logCtx).toBe(ctx);
+      expect(fields).toMatchInlineSnapshot(
+        {
+          headers: {
+            host: expect.any(String),
+          },
+          latency: expect.any(Number),
+          'x-request-id': expect.any(String),
+        },
+        `
+        Object {
+          "headers": Object {
+            "accept-encoding": "gzip, deflate",
+            "authenticated-user": "🐨 REDACTED 🙅",
+            "connection": "close",
+            "content-length": "0",
+            "host": Any<String>,
+            "user-agent": "Safari",
+          },
+          "latency": Any<Number>,
+          "method": "POST",
+          "status": 201,
+          "url": "/my/test/service",
+          "x-request-id": Any<String>,
+        }
+      `,
+      );
 
-      expect(typeof fields).toEqual('object');
-
-      const fieldsObj = fields as Record<string, unknown>;
-      expect(fieldsObj.latency).toBeGreaterThanOrEqual(0);
-      expect(fieldsObj.status).toBe(201);
-      expect(fieldsObj.headers).toEqual({
-        'Authenticated-User': '🐨 REDACTED 🙅',
-        'user-agent': 'Safari',
-      });
-
-      expect(error).toBeUndefined();
+      expect(err).toBeUndefined();
     });
 
     it('skips logging if the handler requests it', async () => {
+      const handler = jest.fn((ctx: Context) => {
+        ctx.status = 201;
+        ctx.state.skipRequestLogging = true;
+      });
+
       const logMock = jest.fn();
-      const ctx = ({
-        response: {
-          status: 200,
-        },
-        state: {},
-      } as unknown) as Koa.Context;
 
       const middleware = createMiddleware(logMock);
 
-      await middleware(ctx, () => {
-        ctx.state.skipRequestLogging = true;
-        return Promise.resolve();
-      });
+      await createAgent(middleware, handler)
+        .post('/my/test/service')
+        .set('Authenticated-User', 'somesercret')
+        .set('user-agent', 'Safari')
+        .expect(201);
 
-      expect(logMock).toBeCalledTimes(0);
+      expect(logMock).not.toBeCalled();
     });
 
     it('logs a failed request', async () => {
+      const expectedError = Error('Something tragic happened');
+
+      // Avoid `console.error` logging
+      const errorHandler = jest.fn(async (ctx: Context, next: Next) => {
+        try {
+          await next();
+        } catch (err) {
+          // Nonsense status code; the caller sees this but not the middleware
+          ctx.status = 418;
+        }
+      });
+
+      const handler = jest.fn(() => {
+        throw expectedError;
+      });
+
       const logMock = jest.fn();
-      const ctx = ({
-        request: {
-          method: 'POST',
-          url: '/my/failed/service',
-          header: {
-            ACCEPT: 'image/png',
-            authorization: 'retain-me',
-            'X-Custom-Header': 'foo',
-          },
-        },
-        response: {
-          status: 404,
-        },
-        state: {},
-      } as unknown) as Koa.Context;
 
       const headerReplacements = {
         'x-custom-header': 'substitution',
@@ -113,33 +169,49 @@ describe('RequestLogging', () => {
 
       const middleware = createMiddleware(logMock, headerReplacements);
 
-      const expectedError = Error('Something tragic happened');
+      await createAgent(errorHandler, middleware, handler)
+        .post('/my/failed/service')
+        .set('ACCEPT', 'image/png')
+        .set('authorization', 'retain-me')
+        .set('X-Custom-Header', 'foo')
+        .set('user-agent', 'Safari')
+        .expect(418);
 
-      await expect(
-        middleware(ctx, () => {
-          throw expectedError;
-        }),
-      ).rejects.toBeDefined();
+      expect(logMock).toBeCalledTimes(1);
 
-      expect(logMock).toHaveBeenCalledTimes(1);
-      const [logCtx, fields, error] = logMock.mock.calls[0] as unknown[];
+      const [, fields, err] = logMock.mock.calls[0];
 
-      expect(logCtx).toBe(ctx);
-
-      expect(typeof fields).toEqual('object');
-
-      const fieldsObj = fields as Record<string, unknown>;
-      expect(fieldsObj.latency).toBeGreaterThanOrEqual(0);
-      expect(fieldsObj.status).toBe(500);
-      expect(fieldsObj.internalErrorString).toBe(
-        'Error: Something tragic happened',
+      expect(fields).toMatchInlineSnapshot(
+        {
+          headers: {
+            host: expect.any(String),
+          },
+          latency: expect.any(Number),
+          'x-request-id': expect.any(String),
+        },
+        `
+        Object {
+          "headers": Object {
+            "accept": undefined,
+            "accept-encoding": "gzip, deflate",
+            "authorization": "retain-me",
+            "connection": "close",
+            "content-length": "0",
+            "host": Any<String>,
+            "user-agent": "Safari",
+            "x-custom-header": "substitution",
+          },
+          "internalErrorString": "Error: Something tragic happened",
+          "latency": Any<Number>,
+          "method": "POST",
+          "status": 500,
+          "url": "/my/failed/service",
+          "x-request-id": Any<String>,
+        }
+      `,
       );
-      expect(fieldsObj.headers).toEqual({
-        authorization: 'retain-me',
-        'X-Custom-Header': 'substitution',
-      });
 
-      expect(error).toBe(expectedError);
+      expect(err).toBe(expectedError);
     });
   });
 });

--- a/src/requestLogging/requestLogging.test.ts
+++ b/src/requestLogging/requestLogging.test.ts
@@ -162,6 +162,7 @@ describe('RequestLogging', () => {
 
       const logMock = jest.fn();
 
+      // Do not redact authorization
       const headerReplacements = {
         'x-custom-header': 'substitution',
         accept: undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,6 +1153,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@koa/router@9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@koa/router/-/router-9.4.0.tgz#734b64c0ae566eb5af752df71e4143edc4748e48"
+  integrity sha512-dOOXgzqaDoHu5qqMEPLKEgLz5CeIA7q8+1W62mCvFVCOqeC71UoTGJ4u1xUSOpIl2J1x2pqrNULkFteUeZW3/A==
+  dependencies:
+    debug "^4.1.1"
+    http-errors "^1.7.3"
+    koa-compose "^4.1.0"
+    methods "^1.1.2"
+    path-to-regexp "^6.1.0"
+
 "@microsoft/tsdoc-config@0.13.6":
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.13.6.tgz#2154785e264edaa515ce5bb2a6c9cd7865f356cf"
@@ -1596,6 +1607,13 @@
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
     "@types/node" "*"
+
+"@types/koa__router@8.0.3":
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/@types/koa__router/-/koa__router-8.0.3.tgz#f6a9ea3428d1025401f5fc21c47c18395ac44cdc"
+  integrity sha512-eS8K49z1x6OaW1ha61kRksVo42L5DWdQUA3kVpH1Kz6TuKBlG0ri42ELA4zSh+xg+6fAqjfuWA7bfNvwVMNXQA==
+  dependencies:
+    "@types/koa" "*"
 
 "@types/mime@*":
   version "2.0.2"
@@ -4700,6 +4718,17 @@ http-errors@^1.6.3, http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-errors@^1.7.3:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.0.tgz#75d1bbe497e1044f51e4ee9e704a62f28d336507"
+  integrity sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 http-proxy-agent@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
@@ -7095,7 +7124,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -7110,7 +7138,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -7129,14 +7156,8 @@ npm@^6.10.3:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -7673,6 +7694,11 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -8618,6 +8644,11 @@ setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 sha@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This gets us ready for `@koa/router`-specific extensions to this module.