### PR TITLE
feat(RequestLogging): Include route and session

### DIFF
--- a/src/requestLogging/requestLogging.test.ts
+++ b/src/requestLogging/requestLogging.test.ts
@@ -32,6 +32,7 @@ describe('RequestLogging', () => {
             "method": "GET",
             "url": "/route/foo?bar",
             "x-request-id": Any<String>,
+            "x-session-id": "8f859d2a-46a7-4b2d-992b-3da4a18b7ab5",
           }
         `,
         );
@@ -40,11 +41,13 @@ describe('RequestLogging', () => {
       return createAgent(handler)
         .get('/route/foo?bar')
         .set('user-agent', 'Safari')
+        .set('x-session-id', '8f859d2a-46a7-4b2d-992b-3da4a18b7ab5')
         .expect(200, 'hello');
     });
 
     it('returns request information for a @koa/router handler', () => {
       const router = new Router().get(
+        'getRoute',
         '/route/:segment',
         jest.fn((ctx: Context) => {
           ctx.status = 200;
@@ -59,6 +62,8 @@ describe('RequestLogging', () => {
             `
             Object {
               "method": "GET",
+              "route": "/route/:segment",
+              "routeName": "getRoute",
               "url": "/route/foo?bar",
               "x-request-id": Any<String>,
             }


### PR DESCRIPTION
This returns the following optional `contextFields`:

- `route`
- `routeName`
- `x-session-id`

These are only set where present, so they shouldn't unnecessarily bloat existing applications that don't make use of `@koa/router` or a session header.

Koala has tried to remain middleware-agnostic to date, but these fields are optional, and `@koa/router` is the clear router of choice in the Koa ecosystem.