### PR TITLE
feat(MetricsMiddleware): Use distribution

### DIFF
--- a/src/metricsMiddleware/metricsMiddleware.ts
+++ b/src/metricsMiddleware/metricsMiddleware.ts
@@ -16,7 +16,7 @@ type TagsForContext = (ctx: Koa.Context) => Record<string, unknown> | undefined;
 /**
  * Creates a new request metrics middleware
  *
- * This records a `request` histogram metric for every request. It will have
+ * This records a `request.distribution` metric for every request. It will have
  * `http_status` and `http_status_family` tags in addition to what's returned
  * by `tagsForContext`.
  *
@@ -32,6 +32,7 @@ type TagsForContext = (ctx: Koa.Context) => Record<string, unknown> | undefined;
 export const create = (
   metricsClient: StatsD,
   tagsForContext: TagsForContext,
+  sampleRate: number = 1,
 ): Koa.Middleware =>
   async function metricsMiddleware(
     ctx: Koa.Context,
@@ -54,7 +55,12 @@ export const create = (
       const durationNanos = process.hrtime.bigint() - startTime;
 
       if (!ctx.state.skipRequestLogging) {
-        metricsClient.timing('request', Number(durationNanos) / 1e6, tags);
+        metricsClient.distribution(
+          'request.distribution',
+          Number(durationNanos) / 1e6,
+          sampleRate,
+          tags,
+        );
       }
     }
   };

--- a/src/metricsMiddleware/statsD.ts
+++ b/src/metricsMiddleware/statsD.ts
@@ -5,5 +5,10 @@ type Tags = { [key: string]: string } | string[];
  * to install `hot-shots` when they are not using MetricsMiddleware.
  */
 export interface StatsD {
-  timing(stat: string | string[], value: number, tags?: Tags): void;
+  distribution(
+    stat: string | string[],
+    value: number,
+    sampleRate?: number,
+    tags?: Tags,
+  ): void;
 }


### PR DESCRIPTION
BREAKING CHANGE: The middleware now emits a `request.distribution` metric instead of a `request` histogram metric. This allows for accurate percentile aggregation.