### PR TITLE
feat(RequestLogging): Include `err` field

### DIFF
--- a/src/requestLogging/README.md
+++ b/src/requestLogging/README.md
@@ -153,6 +153,11 @@ const healthCheckHandler = async (ctx: Koa.Context) => {
   },
   "status": 500,
   "internalErrorString": "ExpiredTokenException: The security token included in the request is expired",
+  "err": {
+    "message": "The security token included in the request is expired",
+    "name": "ExpiredTokenException",
+    "stack": "..."
+  },
   "msg": "request log",
   "time": "2018-10-16T00:44:41.055Z",
   "v": 0

--- a/src/requestLogging/requestLogging.test.ts
+++ b/src/requestLogging/requestLogging.test.ts
@@ -197,6 +197,7 @@ describe('RequestLogging', () => {
         },
         `
         Object {
+          "err": [Error: Something tragic happened],
           "headers": Object {
             "accept": undefined,
             "accept-encoding": "gzip, deflate",


### PR DESCRIPTION
Consuming applications tend towards the following `logFn` boilerplate:

```typescript
const data = {
  ...fields,
  err: err ?? ErrorMiddleware.thrown(ctx),
};
```

While Koala provides a simplified `internalErrorString`, rich error details are often handy for troubleshooting, and the `err` property name is blessed by common logging frameworks like Bunyan and Pino. This preserves `internalErrorString` for backward compatibility.