### PR TITLE
feat(RequestLogging): Add `createContextStorage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Release](https://github.com/seek-oss/koala/workflows/Release/badge.svg?branch=master)](https://github.com/seek-oss/koala/actions?query=workflow%3ARelease)
 [![GitHub Validate](https://github.com/seek-oss/koala/workflows/Validate/badge.svg?branch=master)](https://github.com/seek-oss/koala/actions?query=workflow%3AValidate)
-[![Node.js version](https://img.shields.io/badge/node-%3E%3D%2010-brightgreen)](https://nodejs.org/en/)
+[![Node.js version](https://img.shields.io/badge/node-%3E%3D%2012.17-brightgreen)](https://nodejs.org/en/)
 [![npm package](https://img.shields.io/npm/v/seek-koala)](https://www.npmjs.com/package/seek-koala)
 [![Powered by skuba](https://img.shields.io/badge/🤿%20skuba-powered-009DC4)](https://github.com/seek-oss/skuba)
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@koa/router": "10.1.1",
     "@types/koa": "2.13.4",
     "@types/koa__router": "8.0.11",
-    "@types/node": "12.19",
+    "@types/node": "16.0.0",
     "@types/supertest": "2.0.12",
     "@types/uuid": "8.3.4",
     "hot-shots": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@koa/router": "10.1.1",
     "@types/koa": "2.13.4",
     "@types/koa__router": "8.0.11",
+    "@types/node": "12.19",
     "@types/supertest": "2.0.12",
     "@types/uuid": "8.3.4",
     "hot-shots": "9.0.0",
@@ -18,7 +19,7 @@
     "supertest": "6.2.2"
   },
   "engines": {
-    "node": ">=10.7"
+    "node": ">=12.17"
   },
   "files": [
     "lib*/**/*.d.ts",

--- a/src/requestLogging/README.md
+++ b/src/requestLogging/README.md
@@ -20,7 +20,9 @@ It must be added early in the Koa Middleware chain if you want logger calls to c
 `getFieldsFn` parameter if you wish to provide your own context fields alongside the default [`contextFields`](#context-fields).
 
 ```typescript
-const contextMiddleware = createContextMiddleware((ctx, fields) => ({
+const contextMiddleware = createContextMiddleware();
+
+const customContextMiddleware = createContextMiddleware((ctx, fields) => ({
   advertiserId: ctx.state.advertiserId,
   ...fields,
 }));
@@ -81,7 +83,9 @@ This can be accomplished using the `child` method of Bunyan or pino loggers.
 You may override or supply your own fields using the optional `fields` parameter.
 
 ```typescript
-const fields = contextFields(ctx, { myField: 'hello world!' });
+const fields = contextFields(ctx);
+
+const customFields = contextFields(ctx, { myField: 'hello world!' });
 ```
 
 `contextFields` requires access to the Koa context to generate a stable [`X-Request-Id`].

--- a/src/requestLogging/README.md
+++ b/src/requestLogging/README.md
@@ -13,7 +13,7 @@ It provides three main features:
 
 ## Context Logging
 
-`createContextStorage` returns a logger context storage instance with two methods: `createContextMiddleware` and `mixin`. This is simply a wrapper over an [AsyncLocalStorage](https://nodejs.org/docs/latest-v16.x/api/async_context.html#class-asynclocalstorage) instance.
+`createContextStorage` returns a logger context storage instance with two methods: `createContextMiddleware` and `mixin`. This is simply a wrapper over an [AsyncLocalStorage](https://nodejs.org/docs/latest-v16.x/api/async_context.html#class-asynclocalstorage) instance. Please note: for performance reasons it is recommended that you use Node.js version v16.2.0+ if you intend to use this.
 
 `createContextMiddleware` is a function which returns a Koa Middleware that injects the logger context into an AsyncLocalStorage instance.
 It must be added early in the Koa Middleware chain if you want logger calls to contain request context fields. It also provides an optional

--- a/src/requestLogging/README.md
+++ b/src/requestLogging/README.md
@@ -78,6 +78,12 @@ The route properties assume use of `@koa/router`, and are omitted if the expecte
 The returned object can be used to construct a child logger that annotates log entries with request-specific information.
 This can be accomplished using the `child` method of Bunyan or pino loggers.
 
+You may override or supply your own fields using the optional `fields` parameter.
+
+```typescript
+const fields = contextFields(ctx, { myField: 'hello world!' });
+```
+
 `contextFields` requires access to the Koa context to generate a stable [`X-Request-Id`].
 See the [TracingHeaders add-on](../tracingHeaders/README.md) for more information.
 

--- a/src/requestLogging/README.md
+++ b/src/requestLogging/README.md
@@ -5,7 +5,7 @@
 This add-on facilitates logging information about requests and responses.
 It's intended to work with an app-provided logger such as [pino](http://getpino.io/) or [Bunyan](https://github.com/trentm/node-bunyan).
 
-It provides 3 main features:
+It provides three main features:
 
 - [`createContextStorage`](#context-logging) returns a logger context storage instance.
 - [`contextFields`](#context-fields) returns log fields related to the incoming request.

--- a/src/requestLogging/README.md
+++ b/src/requestLogging/README.md
@@ -40,8 +40,6 @@ const logger = pino({
   mixin,
 });
 
-const loggerContextMiddleware = RequestLogging.createLoggerContextMiddleware(loggerContext);
-
 const helloWorldHandler = async (ctx: Koa.Context) => {
   logger.info('About to return Hello World!');
 

--- a/src/requestLogging/README.md
+++ b/src/requestLogging/README.md
@@ -7,16 +7,19 @@ It's intended to work with an app-provided logger such as [pino](http://getpino.
 
 It provides 3 main features:
 
-- [`createLoggerContextStorage`](#context-logging) auto inject request based information into a logger's context
+- [`createLoggerContextStorage`](#context-logging) returns a logger context storage instance.
 - [`contextFields`](#context-fields) returns log fields related to the incoming request.
 - [`createMiddleware`](#request-log) creates a Koa middleware for logging request and response information
 
 ## Context Logging
 
-`createLoggerContextStorage` returns a logger context storage instance with two methods.
+`createLoggerContextStorage` returns a logger context storage instance with two methods: `contextMiddleware` and `mixin`. This is simply a wrapper over an [AsyncLocalStorage](https://nodejs.org/docs/latest-v16.x/api/async_context.html#class-asynclocalstorage) instance.
 
-`contextMiddleware` which is a Koa Middleware that injects the logger context into an AsyncLocalStorage instance.
-`mixin` which is a function which returns the context fields
+`contextMiddleware` is a function which returns a Koa Middleware that injects the logger context into an AsyncLocalStorage instance.
+It must be added early in the Koa Middleware chain if you want logger calls to contain request context fields. It also provides an optional
+`getFieldsFn` parameter if you wish to provide your own context fields. By default it uses the [`contextFields`](#context-fields) function.
+
+`mixin` is a function which returns the context fields from the storage. It returns an empty object if no context can be found.
 
 Attaching `contextMiddleware` to the Koa middleware chain and the `mixin` function to the logger instance allows you to import the logger instance
 in any file and still retain the current request context fields within log calls.
@@ -57,9 +60,6 @@ const app = new Koa()
   .use(router.routes())
   .use(router.allowedMethods())
 ```
-
-`contextMiddleware` must be added early in the Koa Middleware chain if you want logger calls to contain request context fields.
-It also provides a `getFieldsFn` parameter if you wish to provide your own context fields. By default it uses the [`contextFields`](#context-fields) function.
 
 ## Context Fields
 

--- a/src/requestLogging/README.md
+++ b/src/requestLogging/README.md
@@ -19,10 +19,9 @@ It provides 3 main features:
 It must be added early in the Koa Middleware chain if you want logger calls to contain request context fields. It also provides an optional
 `getFieldsFn` parameter if you wish to provide your own context fields. By default it uses the [`contextFields`](#context-fields) function.
 
-`mixin` is a function which returns the context fields from the storage. It returns an empty object if no context can be found.
+`mixin` is a function which returns the context fields from the storage. It returns an empty object if no context can be found. This should be called every time a logger is called. You can attach this to Pino's [mixin](https://github.com/pinojs/pino/blob/master/docs/api.md#mixin-function) field when you create a logger instance.
 
-Attaching `contextMiddleware` to the Koa middleware chain and the `mixin` function to the logger instance allows you to import the logger instance
-in any file and still retain the current request context fields within log calls.
+Attaching both `contextMiddleware` and `mixin` will then allow you to import the logger instance in any file and still retain the current request context fields within log calls.
 
 ### Usage
 

--- a/src/requestLogging/requestLogging.ts
+++ b/src/requestLogging/requestLogging.ts
@@ -85,6 +85,9 @@ export type ContextFields = (
  *
  * The route properties assume use of `@koa/router`, and are omitted if the
  * expected metadata is not present on context.
+ *
+ * @param ctx - Koa Context
+ * @param fields - Optional fields to add to the context
  */
 export const contextFields: ContextFields = (ctx, fields): Fields => {
   const { adhocSessionID, requestID } = tracingFromContext(ctx);
@@ -183,7 +186,6 @@ export const createContextStorage = () => {
     /**
      * Koa Middleware that injects the logger context into an AsyncLocalStorage instance
      * @param getFieldsFn - Optional function to return a set of fields to include in context. Defaults to `contextFields`
-     * @returns
      */
     createContextMiddleware:
       (getFieldsFn: ContextFields = contextFields): Koa.Middleware =>

--- a/src/requestLogging/requestLogging.ts
+++ b/src/requestLogging/requestLogging.ts
@@ -87,7 +87,7 @@ export type ContextFields = (
  * expected metadata is not present on context.
  *
  * @param ctx - Koa Context
- * @param fields - Optional fields to add to the context
+ * @param fields - Optional fields to add to the object
  */
 export const contextFields: ContextFields = (ctx, fields): Fields => {
   const { adhocSessionID, requestID } = tracingFromContext(ctx);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,10 +1271,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
-"@types/node@12.19":
-  version "12.19.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.16.tgz#15753af35cbef636182d8d8ca55b37c8583cecb3"
-  integrity sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q==
+"@types/node@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
+  integrity sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
+"@types/node@12.19":
+  version "12.19.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.16.tgz#15753af35cbef636182d8d8ca55b37c8583cecb3"
+  integrity sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"


### PR DESCRIPTION
BREAKING CHANGE: The minimum version of Node.js has been bumped up to 12.17

This adds functionality to allow for a root logger instance to retain request based context.

This means you can simply import the logger in any file and the request context will just be there when you call `logger.info`, `logger.error` or any other method.

This means you will no longer need to create a child logger to pass around the codebase in order to retain request context.

This implementation uses the Node.js [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) instance to track logger context.

There is a performance hit of ~1.75% on Node 16.2.0+ according to [this](https://github.com/nodejs/node/issues/34493#issuecomment-845094849) which is negligible