### PR TITLE
feat(TracingHeaders): Use `crypto.randomUUID`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "bugs": {
     "url": "https://github.com/seek-oss/koala/issues"
   },
-  "dependencies": {
-    "uuid": "^8.0.0"
-  },
+  "dependencies": {},
   "description": "Koa add-ons for SEEK-standard tracing, logging and metrics",
   "devDependencies": {
     "@koa/router": "10.1.1",
@@ -12,14 +10,13 @@
     "@types/koa__router": "8.0.11",
     "@types/node": "16.0.0",
     "@types/supertest": "2.0.12",
-    "@types/uuid": "8.3.4",
     "hot-shots": "9.0.0",
     "koa": "2.13.4",
     "skuba": "4.2.2",
     "supertest": "6.2.2"
   },
   "engines": {
-    "node": ">=12.17"
+    "node": ">=14.17"
   },
   "files": [
     "lib*/**/*.d.ts",

--- a/src/tracingHeaders/tracingHeaders.ts
+++ b/src/tracingHeaders/tracingHeaders.ts
@@ -1,5 +1,6 @@
+import { randomUUID } from 'crypto';
+
 import Koa from 'koa';
-import { v4 as uuidv4 } from 'uuid';
 
 import { AppIdentifier } from '../types';
 
@@ -58,7 +59,7 @@ const generateTracing = (ctx: Koa.Context): SEEKTracing => {
   const header = ctx.request.header as Record<string, string>;
 
   const tracing: SEEKTracing = {
-    requestID: header[REQUEST_ID_HEADER] || uuidv4(),
+    requestID: header[REQUEST_ID_HEADER] || randomUUID(),
   };
 
   for (const [headerName, tracingProp] of SESSION_HEADER_TO_TRACING_PROP) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "lib": ["ES2018"],
+    "lib": ["ES2020"],
     "outDir": "lib",
     "removeComments": false,
-    "target": "ES2018"
+    "target": "ES2020"
   },
   "exclude": ["lib*/**/*"],
   "extends": "skuba/config/tsconfig.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,11 +1382,6 @@
   dependencies:
     "@types/superagent" "*"
 
-"@types/uuid@8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -6904,11 +6899,6 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-uuid@^8.0.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
BREAKING CHANGE: Koala has switched generation of V4 UUID request IDs from the third-party `uuid` module to the built-in `node:crypto` module. The minimum supported Node.js version is now 14.17.0.

https://nodejs.org/docs/latest-v18.x/api/crypto.html#cryptorandomuuidoptions