### PR TITLE
RFC: feat(RequestLogging): Evaluate mixin fields JIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "lint": "skuba lint",
     "release": "yarn build && skuba release",
     "test": "skuba test",
-    "test:ci": "skuba test --coverage"
+    "test:ci": "skuba test --coverage",
+    "test:watch": "skuba test --watch"
   },
   "sideEffects": false,
   "skuba": {

--- a/src/requestLogging/requestLogging.test.ts
+++ b/src/requestLogging/requestLogging.test.ts
@@ -385,6 +385,10 @@ describe('RequestLogging', () => {
         availableAtCallSite: ctx.state.idFromAuthToken,
       }));
 
+      // These should be callable but not useful at this point
+      expect(mixin()).toStrictEqual({});
+      expect(contextMiddleware.mixin()).toStrictEqual({});
+
       // We need to grab the result from within the run() chain
       let staticRootResult: Fields = {};
       let dynamicNestedResult: Fields = {};


### PR DESCRIPTION
Currently, `getFieldsFn` callback passed to `createContextMiddleware` is evaluated once per request when it is invoked in the middleware chain. This amortises the cost of the invocation and reduces the amount of data kept in async local storage.

A downside is that additional information that is added to the Koa context later in the middleware chain cannot be factored in to the logging fields. This is also easy to miss if you have permissive code where the logging fields are simply omitted if they aren't available on the context.

This exposes a nested `mixin` which could support this use case. I'm not convinced that this should be released as is as having two local storages and `mixin`s likely does not make sense outside of backward compatibility.