### PR TITLE
fix(ErrorMiddleware): Only respect certain `err.status`es

### DIFF
--- a/src/errorMiddleware/README.md
+++ b/src/errorMiddleware/README.md
@@ -6,9 +6,9 @@ Catches errors thrown from downstream middleware, as specified here:
 
 <https://github.com/koajs/koa/wiki/Error-Handling#catching-downstream-errors>
 
-This tries to extract a numeric error `status` to serve as the response status,
+If you use `http-errors` or Koa's built-in `ctx.throw`,
+this tries to extract a numeric error `status` to serve as the response status,
 and will set the error message as the response body for non-5xx statuses.
-It works well with Koa's built-in `ctx.throw`.
 
 This should be placed high up the middleware chain so that errors from lower middleware are handled.
 It also serves to set the correct `ctx.status` for middleware that emit logs or metrics containing the response status.
@@ -36,6 +36,51 @@ app
   .use(metricsMiddleware)
   .use(ErrorMiddleware.handle);
 ```
+
+Some HTTP clients throw errors with a `status` property to indicate the status code of the HTTP response. If such an error was not handled by a middleware or controller further up the chain, `ErrorMiddleware.handle` will generally ignore the error status code and respond with a HTTP 500.
+
+Most of the time, this is what you want. For example, if your server depends on an upstream service-to-service endpoint and it starts to respond with HTTP 401s, that may imply that your server is not appropriately authenticated and is at fault, and should default to a HTTP 500.
+
+If you want to throw an error that `ErrorMiddleware.handle` will pick up to modify your response status code, you have three options:
+
+1. Use `http-errors`
+
+   ```typescript
+   import createError from 'http-errors';
+
+   const controller = () => {
+     throw new createError.ImATeapot();
+   };
+   ```
+
+2. Use `ctx.throw`
+
+   ```typescript
+   const controller = (ctx) => {
+     ctx.throw(418, 'Badness!');
+   };
+   ```
+
+3. Include `isJsonResponse` and `status` properties on your error
+
+   ```typescript
+   class MyCustomError extends Error {
+     constructor(
+       message: string,
+       public isJsonResponse: boolean,
+       public status: number,
+     ) {
+       super(message);
+
+       this.isJsonResponse = isJsonResponse;
+       this.status = status;
+     }
+   }
+
+   const controller = () => {
+     throw new MyCustomError('Badness!', false, 418);
+   };
+   ```
 
 ## JsonResponse
 

--- a/src/errorMiddleware/errorMiddleware.test.ts
+++ b/src/errorMiddleware/errorMiddleware.test.ts
@@ -1,3 +1,4 @@
+import createError from 'http-errors';
 import Koa from 'koa';
 import request from 'supertest';
 
@@ -136,6 +137,20 @@ describe('errorMiddleware', () => {
     });
 
     await agent.get('/').expect(500, '');
+  });
+
+  it('respects status from http-errors', async () => {
+    mockNext.mockImplementation(() => {
+      throw new createError.ImATeapot('Badness!');
+    });
+
+    await agent.get('/').expect(418, 'Badness!');
+
+    mockNext.mockImplementation(() => {
+      throw new createError.BadRequest('Badness!');
+    });
+
+    await agent.get('/').expect(400, 'Badness!');
   });
 
   it('respects status if isJsonResponse is present', async () => {

--- a/src/errorMiddleware/errorMiddleware.ts
+++ b/src/errorMiddleware/errorMiddleware.ts
@@ -47,9 +47,9 @@ export class JsonResponse extends Error {
  *
  * https://github.com/koajs/koa/wiki/Error-Handling#catching-downstream-errors
  *
- * This tries to extract a numeric error `status` to serve as the response
- * status, and will set the error message as the response body for non-5xx
- * statuses. It works well with Koa's built-in `ctx.throw`.
+ * If you use `http-errors` or Koa's built-in `ctx.throw`, this tries to extract
+ * a numeric error `status` to serve as the response status, and will set the
+ * error message as the response body for non-5xx statuses.
  *
  * This includes support for a JSON response body by throwing an error with
  * `isJsonResponse` set to `true`. If the request accepts `application/json` the


### PR DESCRIPTION
BREAKING CHANGE: Some HTTP clients throw errors with a `status` property to indicate the status code of the HTTP response. If such an error was not handled by a middleware or controller further up the chain, `ErrorMiddleware.handle` would previously pick up the error and reflect its status code back to your client.

Most of the time, this is not what you want. For example, if your server depends on an upstream service-to-service endpoint and it starts to respond with HTTP 401s, that may imply that your server is not appropriately authenticated and is at fault, and should default to a HTTP 500. This is now the default behaviour of `ErrorMiddleware.handle`.

If you want to throw an error that `ErrorMiddleware.handle` will pick up to modify your response status code, you are now limited to three options:

1. Use `http-errors`

   ```typescript
   import createError from 'http-errors';

   const controller = () => {
     throw new createError.ImATeapot();
   };
   ```

2. Use `ctx.throw`

   ```typescript
   const controller = (ctx) => {
     ctx.throw(418, 'Badness!');
   };
   ```

3. Include `isJsonResponse` and `status` properties on your error

   ```typescript
   class MyCustomError extends Error {
     constructor(
       message: string,
       public isJsonResponse: boolean,
       public status: number,
     ) {
       super(message);

       this.isJsonResponse = isJsonResponse;
       this.status = status;
     }
   }

   const controller = () => {
     throw new MyCustomError('Badness!', false, 418);
   };
   ```