### PR TITLE
fix(ErrorMiddleware): Support multiple `http-errors` versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,15 @@
 {
   extends: ['github>seek-oss/rynovate'],
+  packageRules: [
+    {
+      matchManagers: ['npm'],
+      matchPackageNames: [
+        // Matches transitive Koa dependency
+        'http-errors',
+      ],
+      matchUpdateTypes: ['major'],
+
+      enabled: false,
+    },
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "test": "skuba test",
     "test:ci": "skuba test --coverage"
   },
-  "dependencies": {},
+  "dependencies": {
+    "http-errors": "^1.8.0"
+  },
   "devDependencies": {
     "@koa/router": "12.0.0",
     "@types/koa": "2.13.8",

--- a/src/errorMiddleware/errorMiddleware.test.ts
+++ b/src/errorMiddleware/errorMiddleware.test.ts
@@ -153,6 +153,28 @@ describe('errorMiddleware', () => {
     await agent.get('/').expect(400, 'Badness!');
   });
 
+  it('respects status from a http-errors-compatible error', async () => {
+    mockNext.mockImplementation(() => {
+      throw Object.assign(new Error('Badness!'), {
+        expose: false,
+        status: 418,
+        statusCode: 418,
+      });
+    });
+
+    await agent.get('/').expect(418, 'Badness!');
+
+    mockNext.mockImplementation(() => {
+      throw Object.assign(new Error('Badness!'), {
+        expose: true,
+        status: 400,
+        statusCode: 400,
+      });
+    });
+
+    await agent.get('/').expect(400, 'Badness!');
+  });
+
   it('respects status if isJsonResponse is present', async () => {
     class JsonResponseError extends Error {
       constructor(

--- a/src/errorMiddleware/errorMiddleware.ts
+++ b/src/errorMiddleware/errorMiddleware.ts
@@ -1,4 +1,5 @@
-import { type Context, HttpError, type Middleware } from 'koa';
+import { isHttpError } from 'http-errors';
+import type { Context, Middleware } from 'koa';
 
 /**
  * @see {@link https://github.com/microsoft/TypeScript/issues/1863}
@@ -80,7 +81,7 @@ export const handle: Middleware = async (ctx, next) => {
     if (
       !isObject(err) ||
       typeof err.status !== 'number' ||
-      (!(err instanceof HttpError) && err.isJsonResponse === undefined)
+      (!isHttpError(err) && err.isJsonResponse === undefined)
     ) {
       ctx.status = 500;
       ctx.body = '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,7 +4129,7 @@ http-cache-semantics@^4.1.1:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
-http-errors@^1.6.3, http-errors@~1.8.0:
+http-errors@^1.6.3, http-errors@^1.8.0, http-errors@~1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
   integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==


### PR DESCRIPTION
The `http-errors` handling in v7.0.0 may have not worked when multiple versions of the module were present.