### PR TITLE
Switch to `NPM_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
         run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.SEEK_OSS_CI_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We're switching away from SEEK_OSS_CI_NPM_TOKEN to a scoped NPM_TOKEN per repo. This updates the workflows to reference the scoped token.