### PR TITLE
Add missing id-token perm

### DIFF
--- a/.changeset/two-kids-explode.md
+++ b/.changeset/two-kids-explode.md
@@ -1,0 +1,5 @@
+---
+'seek-koala': patch
+---
+
+Publish with provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo


### PR DESCRIPTION
Add missing `id-token` for koala. Snapshots are fine, but if we go to release this it should fail