### PR TITLE
Remove `Install latest npm` step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
       - name: Publish to npm
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
@@ -68,9 +65,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Install latest npm
-        run: npm install -g npm@latest
 
       - name: Publish to npm
         uses: seek-oss/changesets-snapshot@9063bfcb495100964ee0912c5bcb30c4c434c1b3 # v0.3.2


### PR DESCRIPTION
## Summary

- Removes the `Install latest npm` step from the release workflow.

Node.js now ships with an up-to-date version of npm, making this step unnecessary. Additionally, npm 12 has broken our release workflows, so explicitly upgrading to the latest npm is now harmful rather than helpful.

Made with [Cursor](https://cursor.com)